### PR TITLE
Disable logging via spdlog

### DIFF
--- a/sdk/cpp/core/src/logger.hpp
+++ b/sdk/cpp/core/src/logger.hpp
@@ -20,114 +20,112 @@
 #include <memory>
 #include <sstream>
 
-#include "spdlog/spdlog.h"
 #include "logging_callback.hpp"
+#include "spdlog/spdlog.h"
 
-
-namespace spdlog
-{
+namespace spdlog {
 class logger;
 }
 
-namespace ydk
-{
+namespace ydk {
 
-class Logger
-{
-    public:
-        Logger()
-            : internal_logger{ spdlog::get("ydk") }
-        {
-        }
+// class Logger
+// {
+//     public:
+//         Logger()
+//             : internal_logger{ spdlog::get("ydk") }
+//         {
+//         }
 
-        ~Logger()
-        {
-        }
-        #define _STRINGIFY(x) #x
-        #define STRINGIFY(x) _STRINGIFY(x)
-        #define YDKLOGLEVELARGS(loglevel) \
-        template <typename... Args> \
-        void loglevel(const char* fmt, const Args&... args) \
-        { \
-            logging_callback func = get_logging_callback(STRINGIFY(loglevel)); \
-            if(func != nullptr) \
-                { \
-                    std::stringstream buffer; \
-                    write_fmt_msg<Args...>(internal_logger->name(), \
-                                           STRINGIFY(loglevel), \
-                                           fmt, \
-                                           buffer, \
-                                           args...); \
-                    func(buffer.str().c_str()); \
-                    return;\
-                } \
-            /* Only applies to C++ core */ \
-            if(!lazy_check()) { return; } \
-            internal_logger->loglevel<Args...>(fmt, args...); \
-        }
+//         ~Logger()
+//         {
+//         }
+//         #define _STRINGIFY(x) #x
+//         #define STRINGIFY(x) _STRINGIFY(x)
+//         #define YDKLOGLEVELARGS(loglevel) \
+//         template <typename... Args> \
+//         void loglevel(const char* fmt, const Args&... args) \
+//         { \
+//             logging_callback func =
+//             get_logging_callback(STRINGIFY(loglevel)); \
+//             if(func != nullptr) \
+//                 { \
+//                     std::stringstream buffer; \
+//                     write_fmt_msg<Args...>(internal_logger->name(), \
+//                                            STRINGIFY(loglevel), \
+//                                            fmt, \
+//                                            buffer, \
+//                                            args...); \
+//                     func(buffer.str().c_str()); \
+//                     return;\
+//                 } \
+//             /* Only applies to C++ core */ \
+//             if(!lazy_check()) { return; } \
+//             internal_logger->loglevel<Args...>(fmt, args...); \
+//         }
 
-        #define YDKLOGLEVELNOARGS(loglevel) \
-        template <typename T> \
-        void loglevel(const T& msg) \
-        { \
-            logging_callback func = get_logging_callback(STRINGIFY(loglevel)); \
-            if(func != nullptr) { func(msg); return; } \
-            /* Only applies to C++ core */ \
-            if(!lazy_check()) { return; } \
-            internal_logger->loglevel<T>(msg); \
-        }
+//         #define YDKLOGLEVELNOARGS(loglevel) \
+//         template <typename T> \
+//         void loglevel(const T& msg) \
+//         { \
+//             logging_callback func = get_logging_callback(STRINGIFY(loglevel)); \
+//             if(func != nullptr) { func(msg); return; } \
+//             /* Only applies to C++ core */ \
+//             if(!lazy_check()) { return; } \
+//             internal_logger->loglevel<T>(msg); \
+//         }
 
-        YDKLOGLEVELARGS(trace)
-        YDKLOGLEVELARGS(debug)
-        YDKLOGLEVELARGS(info)
-        YDKLOGLEVELARGS(warn)
-        YDKLOGLEVELARGS(error)
-        YDKLOGLEVELARGS(critical)
+//         YDKLOGLEVELARGS(trace)
+//         YDKLOGLEVELARGS(debug)
+//         YDKLOGLEVELARGS(info)
+//         YDKLOGLEVELARGS(warn)
+//         YDKLOGLEVELARGS(error)
+//         YDKLOGLEVELARGS(critical)
 
-        YDKLOGLEVELNOARGS(trace)
-        YDKLOGLEVELNOARGS(debug)
-        YDKLOGLEVELNOARGS(info)
-        YDKLOGLEVELNOARGS(warn)
-        YDKLOGLEVELNOARGS(error)
-        YDKLOGLEVELNOARGS(critical)
+//         YDKLOGLEVELNOARGS(trace)
+//         YDKLOGLEVELNOARGS(debug)
+//         YDKLOGLEVELNOARGS(info)
+//         YDKLOGLEVELNOARGS(warn)
+//         YDKLOGLEVELNOARGS(error)
+//         YDKLOGLEVELNOARGS(critical)
 
-        #undef YDKLOGLEVELARGS
-        #undef YDKLOGLEVELNOARGS
-        #undef _STRINGIFY
-        #undef STRINGIFY
+//         #undef YDKLOGLEVELARGS
+//         #undef YDKLOGLEVELNOARGS
+//         #undef _STRINGIFY
+//         #undef STRINGIFY
 
-    private:
-        bool lazy_check()
-        {
-            if (!is_logger_found())
-            {
-                internal_logger = spdlog::get("ydk");
-                if (!is_logger_found())
-                {
-                    return false;
-                }
-            }
-            return true;
-        }
+//     private:
+//         bool lazy_check()
+//         {
+//             if (!is_logger_found())
+//             {
+//                 internal_logger = spdlog::get("ydk");
+//                 if (!is_logger_found())
+//                 {
+//                     return false;
+//                 }
+//             }
+//             return true;
+//         }
 
-        bool is_logger_found()
-        {
-            return (internal_logger != nullptr);
-        }
+//         bool is_logger_found()
+//         {
+//             return (internal_logger != nullptr);
+//         }
 
-    private:
-        std::shared_ptr<spdlog::logger> internal_logger;
-};
+//     private:
+//         std::shared_ptr<spdlog::logger> internal_logger;
+// };
 
-static Logger logger{};
+// static Logger logger{};
 
-#define YLOG_TRACE(...) logger.trace(__VA_ARGS__)
-#define YLOG_DEBUG(...) logger.debug(__VA_ARGS__)
-#define YLOG_INFO(...) logger.info(__VA_ARGS__)
-#define YLOG_WARN(...) logger.warn(__VA_ARGS__)
-#define YLOG_ERROR(...) logger.error(__VA_ARGS__)
-#define YLOG_CRITICAL(...) logger.critical(__VA_ARGS__)
+#define YLOG_TRACE(...) do {}while(0)
+#define YLOG_DEBUG(...) do {}while(0)
+#define YLOG_INFO(...) do {}while(0)
+#define YLOG_WARN(...) do {}while(0)
+#define YLOG_ERROR(...) do {}while(0)
+#define YLOG_CRITICAL(...) do {}while(0)
 
-}
+}  // namespace ydk
 
 #endif /* _LOGGER_H_ */

--- a/sdk/cpp/core/src/logging_callback.hpp
+++ b/sdk/cpp/core/src/logging_callback.hpp
@@ -19,43 +19,45 @@
 #define _LOGGING_CALLBACK_H
 
 #include <sstream>
+
 #include "spdlog/spdlog.h"
 
-namespace ydk
-{
-typedef void (*logging_callback)(const char *msg);
+namespace ydk {
+typedef void (*logging_callback)(const char* msg);
 
 void set_logging_callback(const char* level, logging_callback func);
 logging_callback get_logging_callback(const char* level);
 
 void set_libyang_logging_callback();
 
-static const char trace [] = "trace";
-static const char debug [] = "debug";
-static const char info [] = "info";
-static const char warn [] = "warn";
+static const char trace[] = "trace";
+static const char debug[] = "debug";
+static const char info[] = "info";
+static const char warn[] = "warn";
 static const char error[] = "error";
 static const char critical[] = "critical";
 
-template <typename... Args>
-void write_fmt_msg(const std::string& name, const char* level, const char* fmt, std::stringstream& buffer, const Args&... args)
-{
-    spdlog::level::level_enum lvl;
+// template <typename... Args>
+// void write_fmt_msg(const std::string& name, const char* level, const char*
+// fmt, std::stringstream& buffer, const Args&... args)
+// {
+//     spdlog::level::level_enum lvl;
 
-    if (!strcmp(level, trace)) { lvl = spdlog::level::level_enum::trace ; }
-    if (!strcmp(level, debug)) { lvl = spdlog::level::level_enum::debug ; }
-    if (!strcmp(level, info)) { lvl = spdlog::level::level_enum::info ; }
-    if (!strcmp(level, warn)) { lvl = spdlog::level::level_enum::warn ; }
-    if (!strcmp(level, error)) { lvl = spdlog::level::level_enum::err ; }
-    if (!strcmp(level, critical)) { lvl = spdlog::level::level_enum::critical ; }
+//     if (!strcmp(level, trace)) { lvl = spdlog::level::level_enum::trace ; }
+//     if (!strcmp(level, debug)) { lvl = spdlog::level::level_enum::debug ; }
+//     if (!strcmp(level, info)) { lvl = spdlog::level::level_enum::info ; }
+//     if (!strcmp(level, warn)) { lvl = spdlog::level::level_enum::warn ; }
+//     if (!strcmp(level, error)) { lvl = spdlog::level::level_enum::err ; }
+//     if (!strcmp(level, critical)) { lvl = spdlog::level::level_enum::critical
+//     ; }
 
-    spdlog::details::log_msg log_msg(&name, lvl);
-    log_msg.raw.write(fmt, args...);
+//     spdlog::details::log_msg log_msg(&name, lvl);
+//     log_msg.raw.write(fmt, args...);
 
-    // need to keep buffer alive until logging callback function finished execution
-    buffer << log_msg.raw.str();
-}
+//     // need to keep buffer alive until logging callback function finished
+//     execution buffer << log_msg.raw.str();
+// }
 
-}
+}  // namespace ydk
 
 #endif /* _LOGGING_CALLBACK_H */

--- a/sdk/cpp/core/src/path/path.cpp
+++ b/sdk/cpp/core/src/path/path.cpp
@@ -190,7 +190,7 @@ static ydk::path::RootSchemaNodeImpl & get_root_schema_impl(ydk::path::RootSchem
 
 static std::shared_ptr<ydk::path::DataNode> perform_decode(ydk::path::RootSchemaNodeImpl & rs_impl, struct lyd_node *lnode)
 {
-    ydk::YLOG_DEBUG("Performing decode operation");
+    YLOG_DEBUG("Performing decode operation");
     std::shared_ptr<ydk::path::RootDataImpl> rd = std::make_shared<ydk::path::RootDataImpl> (rs_impl, rs_impl.m_ctx, "/");
     rd->m_node = lnode;
 
@@ -209,7 +209,7 @@ static struct lyd_node* create_lyd_node_for_rpc(ydk::path::RootSchemaNodeImpl & 
     struct lyd_node* rpc = lyd_new_path(NULL, rs_impl.m_ctx, rpc_path.c_str(), NULL, LYD_ANYDATA_SXML, 0);
     if( rpc == nullptr || ly_errno )
     {
-        ydk::YLOG_ERROR( "Parsing failed with message {}", ly_errmsg());
+        YLOG_ERROR( "Parsing failed with message {}", ly_errmsg());
         throw(ydk::path::YCodecError{ydk::path::YCodecError::Error::XML_INVAL});
     }
     return rpc;
@@ -261,7 +261,7 @@ ydk::path::Codec::encode(const ydk::path::DataNode& dn, ydk::EncodingFormat form
             {
                 std::ostringstream os;
                 os << "Could not encode datanode: "<< m_node->schema->name;
-                ydk::YLOG_ERROR(os.str().c_str());
+                YLOG_ERROR(os.str().c_str());
                 throw(ydk::path::YCoreError{os.str()});
             }
             ret = buffer;

--- a/sdk/cpp/core/src/ydk.cpp
+++ b/sdk/cpp/core/src/ydk.cpp
@@ -897,80 +897,80 @@ const char* DataNodeGetSegmentPath(DataNode datanode)
     return string_to_array(segments.back());
 }
 
-void EnableLogging(LogLevel level)
+void EnableLogging(LogLevel )
 {
-    auto console = spdlog::stdout_color_mt("ydk");
-    switch(level)
-    {
-        case DEBUG:
-            console->set_level(spdlog::level::debug);
-            return;
-
-        case INFO:
-            console->set_level(spdlog::level::info);
-            return;
-
-        case WARNING:
-            console->set_level(spdlog::level::warn);
-            return;
-
-        case ERROR:
-            console->set_level(spdlog::level::err);
-            return;
-
-        case OFF:
-            console->set_level(spdlog::level::off);
-            return;
-    }
+//    auto console = spdlog::sinks::stdout_color_mt("ydk");
+//    switch(level)
+//    {
+//        case DEBUG:
+//            console->set_level(spdlog::level::debug);
+//            return;
+//
+//        case INFO:
+//            console->set_level(spdlog::level::info);
+//            return;
+//
+//        case WARNING:
+//            console->set_level(spdlog::level::warn);
+//            return;
+//
+//        case ERROR:
+//            console->set_level(spdlog::level::err);
+//            return;
+//
+//        case OFF:
+//            console->set_level(spdlog::level::off);
+//            return;
+//    }
 }
 
 LogLevel GetLoggingLevel(void)
 {
-    auto console = spdlog::get("ydk");
-    if(console == nullptr)
-    {
-        return OFF;
-    }
-
-    auto level = console->level();
-    switch(level)
-    {
-        case spdlog::level::off:
-            return OFF;
-        case spdlog::level::trace:
-        case spdlog::level::debug:
-            return DEBUG;
-
-        case spdlog::level::info:
-            return INFO;
-
-        case spdlog::level::warn:
-            return WARNING;
-
-        case spdlog::level::critical:
-        case spdlog::level::err:
-        default:
-            return ERROR;
-    }
+    return OFF;
+//    auto console = spdlog::get("ydk");
+//    if(console == nullptr)
+//    {
+//        return OFF;        
+//    }
+//
+//    auto level = console->level();
+//    switch(level)
+//    {
+//        case spdlog::level::off:
+//            return OFF;
+//        case spdlog::level::trace:
+//        case spdlog::level::debug:
+//            return DEBUG;
+//
+//        case spdlog::level::info:
+//            return INFO;
+//
+//        case spdlog::level::warn:
+//            return WARNING;
+//
+//        case spdlog::level::critical:
+//        case spdlog::level::err:
+//        default:
+//            return ERROR;
+//    }
 }
 
 void YLogInfo(const char* msg)
 {
-    ydk::YLOG_INFO(msg);
+    YLOG_INFO(msg);
 }
 
 void YLogDebug(const char* msg)
 {
-    ydk::YLOG_DEBUG(msg);
+    YLOG_DEBUG(msg);
 }
 
 void YLogWarn(const char* msg)
 {
-    ydk::YLOG_WARN(msg);
+    YLOG_WARN(msg);
 }
 
 void YLogError(const char* msg)
 {
-    ydk::YLOG_ERROR(msg);
+    YLOG_ERROR(msg);
 }
-


### PR DESCRIPTION
Avoid spdlog usage by ydk code. The change is required for involving spdlog as a main logger in siklu-main code.