### PR TITLE
DEV-5480: Fix crash on updating mep

### DIFF
--- a/sdk/cpp/core/src/entity.cpp
+++ b/sdk/cpp/core/src/entity.cpp
@@ -51,6 +51,81 @@ Entity::~Entity() {}
 
 shared_ptr<Entity> Entity::clone_ptr() const { return nullptr; }
 
+static void copy_leaves(const Entity *original_entity,
+                        shared_ptr<Entity> cloned_entity) {
+  for (const pair<string, LeafData> &name_value :
+       original_entity->get_name_leaf_data()) {
+    LeafData leaf_data = name_value.second;
+    if (leaf_data.is_set) {
+      YLOG_DEBUG("Creating leaf '{}' of '{}' with value: '{}'",
+                 name_value.first, original_entity->yang_name, leaf_data.value);
+      auto leaf_name = name_value.first;
+      auto leaf_value = leaf_data.value;
+      auto bracket_pos = leaf_name.find("[");
+      if (bracket_pos != string::npos) {
+        // Here we have leaf-list
+        leaf_value = leaf_name.substr(bracket_pos + 4,
+                                      leaf_name.length() - bracket_pos - 6);
+        leaf_name = leaf_name.substr(0, bracket_pos);
+      }
+      cloned_entity->set_value(leaf_name, leaf_value, leaf_data.name_space,
+                               leaf_data.name_space_prefix);
+    }
+  }
+}
+
+static bool copy_children(const Entity *original_entity,
+                          shared_ptr<Entity> cloned_entity) {
+  map<string, shared_ptr<Entity>> children = original_entity->get_children();
+  for (auto const &child : children) {
+    if (child.second == nullptr) continue;
+    YLOG_DEBUG("==================");
+    YLOG_DEBUG("Looking at child '{}' of {}", child.first,
+               original_entity->yang_name);
+    if (child.second->has_data() || child.second->is_presence_container) {
+      YLOG_DEBUG("Going into child {} in parent {}", child.first,
+                 original_entity->yang_name);
+      shared_ptr<Entity> child_entity;
+      auto child_name = child.first;
+      auto bracket_pos = child_name.find("[");
+      if (bracket_pos != string::npos) {
+        child_name = child_name.substr(0, bracket_pos);
+      }
+      if (child.second->ylist) {
+        child_entity =
+            cloned_entity->get_child_by_name(child_name, child.first);
+      } else {
+        child_entity = cloned_entity->get_child_by_name(child_name);
+      }
+
+      if (child_entity == nullptr) {
+        YLOG_ERROR("Could not fetch child entity {} in parent {}!", child_name,
+                   cloned_entity->yang_name);
+        return false;
+      } else {
+        YLOG_DEBUG("Created entity child '{}' in parent '{}'",
+                   child_entity->get_segment_path(), cloned_entity->yang_name);
+      }
+      child_entity->parent = cloned_entity.get();
+      copy_leaves(child.second.get(), child_entity);
+      copy_children(child.second.get(), child_entity);
+
+      if (child_entity->ylist && child_entity->ylist_key_names.size() > 0) {
+        child_entity->ylist->review(child_entity);
+      }
+    } else {
+      YLOG_DEBUG("Child has no data");
+    }
+  }
+  return true;
+}
+
+shared_ptr<Entity> Entity::clone() const {
+  shared_ptr<Entity> cloned_entity = clone_ptr();
+  copy_leaves(this, cloned_entity);
+  return copy_children(this, cloned_entity) ? cloned_entity : nullptr;
+}
+
 void Entity::set_parent(Entity *p) { parent = p; }
 
 Entity *Entity::get_parent() const { return parent; }

--- a/sdk/cpp/core/src/types.hpp
+++ b/sdk/cpp/core/src/types.hpp
@@ -192,6 +192,9 @@ class Identity {
 
   std::string to_string() { return tag; }
 
+  virtual std::shared_ptr<Entity> clone_ptr() const;
+  std::shared_ptr<Entity> clone() const;
+
  public:
   std::string name_space;
   std::string namespace_prefix;

--- a/sdk/cpp/core/src/types.hpp
+++ b/sdk/cpp/core/src/types.hpp
@@ -151,11 +151,11 @@ class Entity {
   Entity* parent = nullptr;
   std::string yang_name;
   std::string yang_parent_name;
-  YFilter yfilter;
-  bool is_presence_container;
-  bool is_top_level_class;
-  bool has_list_ancestor;
-  bool ignore_validation;
+  YFilter yfilter = ydk::YFilter::merge;
+  bool is_presence_container = false;
+  bool is_top_level_class = false;
+  bool has_list_ancestor = false;
+  bool ignore_validation = false;
   std::vector<std::string> ylist_key_names;
   std::string ylist_key;
   YList* ylist = nullptr;

--- a/sdk/python/core/ydk/types/py_types.py
+++ b/sdk/python/core/ydk/types/py_types.py
@@ -71,7 +71,7 @@ class YLeafList(_YLeafList):
 
     def set(self, other):
         if not isinstance(other, YLeafList):
-            raise YModelError("Invalid value '{}' assigned to YLeafList '{}'".format(other, self.leaf_name))
+            raise YModelError("Invalid value '{}' in '{}'".format(other, self.leaf_name))
         else:
             super().clear()
             for item in other:


### PR DESCRIPTION
Uninitailzed types caused undefined behaviour and resulted in a crash of our CLI.
This PR fixes this crash by initializing common ydk types which should also help to prevent similar crashes in the future.