### PR TITLE
DEV-865: Fix XML encoding for enum leaf-lists in YDK

### DIFF
--- a/sdk/cpp/core/src/value_list.cpp
+++ b/sdk/cpp/core/src/value_list.cpp
@@ -211,13 +211,13 @@ std::vector<std::pair<std::string, LeafData>> YLeafList::get_name_leafdata()
   std::vector<std::pair<std::string, LeafData>> name_values;
   for (auto value : values) {
     auto leaf_name_data = value.get_name_leafdata();
-        auto val = value.get();
-        if (value.type == YType::boolean)
-        {
-            val = get_bool_string(val);
-        }name_values.push_back(
-        {(leaf_name_data.first + "[.=\"" + val + "\"]"),
-         {"", yfilter, value.is_set, value.value_namespace,
+    auto val = value.get();
+    if (value.type == YType::boolean) {
+      val = get_bool_string(val);
+    }
+    name_values.push_back(
+        {leaf_name_data.first,
+         {val, yfilter, value.is_set, value.value_namespace,
           value.value_namespace_prefix}});
   }
   return name_values;


### PR DESCRIPTION
Corrected YLeafList::get_name_leafdata() to return proper name/value pairs for leaf-list elements, removing incorrect XPath-style name construction.
the old code always put the value into the name (as leaf_name[.="value"]) instead of as the XML element content. This broke enum and all other non-boolean leaf-lists.
Updated XML codec logic to treat each leaf-list value as a simple leaf, ensuring enum values are encoded as <leaf-list>enum-value</leaf-list>.
Resolves corruption where enum leaf-lists were previously encoded as XPath expressions.